### PR TITLE
Fix hardcoded token URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Changelog
 
-### 0.1.7-1 (2021-01-27)
- * `Governor`: fix vulnerability to ill-formed ProposalCreated events
+### 0.1.9
+* Implement `Naut` module
+* Fix `ERC721` and `ERC1155` implementations not updating token URIs on every load; they were only set once on initialisation and never updated.
+
+### All changes below this line were inherited from the OZ package.
+
+### 0.1.8 (2022-03-18)
  * Update dependency to @graphprotocol/graph-cli version 0.29.x
  * Update dependency to @graphprotocol/graph-ts version 0.26.x
  * Update dependency to @amxx/graphprotocol-utils version 1.1.0
  * Use Bytes for some entities ID
  * Make events and some other entites immutable
  * `Governor`: index the "counting mode" for OZ governors
+
+### 0.1.7-1 (2021-01-27)
+ * `Governor`: fix vulnerability to ill-formed ProposalCreated events
 
 ### 0.1.7 (2021-01-27)
  * `ERC1155`: fetch token uri on minting.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wanderers/subgraphs",
   "description": "Subgraph templates for @openzeppelin/contracts, extended for the Wanderverse.",
-  "version": "0.1.7-1",
+  "version": "0.1.9",
   "contributors": [
     "OpenZeppelin Community <maintainers@openzeppelin.org>",
     "Wanderers <hello@wanderers.ai>"

--- a/src/fetch/erc1155.ts
+++ b/src/fetch/erc1155.ts
@@ -47,15 +47,16 @@ export function fetchERC1155Token(contract: ERC1155Contract, identifier: BigInt)
 	let token = ERC1155Token.load(id)
 
 	if (token == null) {
-		let erc1155            = IERC1155.bind(Address.fromBytes(contract.id))
-		let try_uri            = erc1155.try_uri(identifier)
 		token                  = new ERC1155Token(id)
 		token.contract         = contract.id
 		token.identifier       = identifier
 		token.totalSupply      = fetchERC1155Balance(token as ERC1155Token, null).id
-		token.uri              = try_uri.reverted ? null : replaceURI(try_uri.value, identifier)
 		token.save()
 	}
+
+	let erc1155 = IERC1155.bind(Address.fromBytes(contract.id))
+	let try_uri = erc1155.try_uri(identifier)
+	token.uri = try_uri.reverted ? null : replaceURI(try_uri.value, identifier)
 
 	return token as ERC1155Token
 }

--- a/src/fetch/erc721.ts
+++ b/src/fetch/erc721.ts
@@ -79,12 +79,12 @@ export function fetchERC721Token(contract: ERC721Contract, identifier: BigInt): 
 		token.contract   = contract.id
 		token.identifier = identifier
 		token.approval   = fetchAccount(constants.ADDRESS_ZERO).id
+	}
 
-		if (contract.supportsMetadata) {
-			let erc721       = IERC721.bind(Address.fromBytes(contract.id))
-			let try_tokenURI = erc721.try_tokenURI(identifier)
-			token.uri        = try_tokenURI.reverted ? '' : try_tokenURI.value
-		}
+	if (contract.supportsMetadata) {
+		let erc721       = IERC721.bind(Address.fromBytes(contract.id))
+		let try_tokenURI = erc721.try_tokenURI(identifier)
+		token.uri        = try_tokenURI.reverted ? '' : try_tokenURI.value
 	}
 
 	return token as ERC721Token


### PR DESCRIPTION
- Fix `ERC721` and `ERC1155` implementations not updating URIs on every load (only set once on entity initialisation and then never updated).